### PR TITLE
add close pipe on error

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -165,9 +165,12 @@ func main() {
 			if err != nil {
 				if err == io.EOF {
 					infoLog.Println("Client disconnected")
+				} else if strings.Contains(err.Error(), "The handle is invalid") {
+					infoLog.Println("Pipe handle is invalid (client likely disconnected)")
 				} else {
 					errorLog.Println("Error reading from pipe:", err)
 				}
+				file.Close() // Always close file on error
 				break
 			}
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -165,12 +165,14 @@ func main() {
 			if err != nil {
 				if err == io.EOF {
 					infoLog.Println("Client disconnected")
-				} else if strings.Contains(err.Error(), "The handle is invalid") {
+				} else if errors.Is(err, syscall.Errno(windows.ERROR_INVALID_HANDLE)) {
 					infoLog.Println("Pipe handle is invalid (client likely disconnected)")
 				} else {
 					errorLog.Println("Error reading from pipe:", err)
 				}
-				file.Close() // Always close file on error
+				if closeErr := file.Close(); closeErr != nil {
+					errorLog.Println("Error closing file:", closeErr)
+				} // Always close file on error
 				break
 			}
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -170,9 +171,10 @@ func main() {
 				} else {
 					errorLog.Println("Error reading from pipe:", err)
 				}
+				
 				if closeErr := file.Close(); closeErr != nil {
 					errorLog.Println("Error closing file:", closeErr)
-				} // Always close file on error
+				} 
 				break
 			}
 


### PR DESCRIPTION
now closes and reconnects the pipe when the "Handle is invalid" error occurs due to Windows closing the named pipe