### PR TITLE
add --container command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ krun [global options] <command> [command options] <service>
   krun debug list
   ```
 
-- `debug enable <service> [--intercept]`  
+- `debug enable <service> [--intercept, --container <container>]`  
   Enable debug mode for a service using Telepresence.  
   Use `--intercept` to intercept the service in the Kubernetes cluster, allowing you to run it both locally and in the cluster.  
   If `--intercept` is not specified, it will replace the service in the cluster and redirect traffic to your local debug session.
@@ -78,6 +78,12 @@ krun [global options] <command> [command options] <service>
   ```
 
   Both replace and intercept mode need a port configured that matches the port your application is listening on. For example, a C# web api application usually listens on port `5000` which is defined in the `launchSettings.json` file. To make this available for krun, you need to add the `intercept_port` property in your `krun.json` file for the service you want to debug.
+
+Use the `--container` option to specify which container to debug if your pod has multiple containers.
+
+```sh
+krun debug enable awesome-app-api --container awesome-app-api
+```
 
 - `debug disable <service>`  
   Disable debug mode for a service.
@@ -116,6 +122,12 @@ krun [global options] <command> [command options] <service>
 
    ```sh
    krun debug enable awesome-app-api
+   ```
+
+1. Enable debug mode for specific conttainer:
+
+   ```sh
+   krun debug enable awesome-app-api --container mysidecar
    ```
 
 1. Disable debug mode:

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -39,6 +39,7 @@ type PipeCommand struct {
 	ServicePort   int    `json:"service_port,omitempty"`
 	Intercept     bool   `json:"intercept,omitempty"`
 	InterceptPort int    `json:"intercept_port,omitempty"`
+	ContainerName string `json:"container_name,omitempty"`
 }
 
 type PipeResponse struct {
@@ -228,7 +229,11 @@ func debugEnable(cmd PipeCommand) {
 		port = fmt.Sprintf("%d", cmd.InterceptPort)
 	}
 
-	execCmd := exec.Command("telepresence", mode, cmd.ServiceName, "--port", port, "--env-file", filepath.Join(cmd.ServicePath, "appsettings-debug.env"), "--mount", "false")
+	telepresenceArgs := []string{mode, cmd.ServiceName, "--port", port, "--env-file", filepath.Join(cmd.ServicePath, "appsettings-debug.env"), "--mount", "false"}
+	if cmd.ContainerName != "" {
+		telepresenceArgs = append(telepresenceArgs, "--container", cmd.ContainerName)
+	}
+	execCmd := exec.Command("telepresence", telepresenceArgs...)
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 	err := execCmd.Run()

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -8,6 +8,7 @@ type PipeCommand struct {
 	ServicePort   int    `json:"service_port,omitempty"`
 	Intercept     bool   `json:"intercept,omitempty"`
 	InterceptPort int    `json:"intercept_port,omitempty"`
+	ContainerName string `json:"container_name,omitempty"`
 }
 
 type PipeResponse struct {

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func Enable(service cfg.Service, config cfg.Config, intercept bool) {
+func Enable(service cfg.Service, config cfg.Config, intercept bool, containerName string) {
 
 	cmd := contracts.PipeCommand{
 		Command: "debug_enable",
@@ -21,6 +21,7 @@ func Enable(service cfg.Service, config cfg.Config, intercept bool) {
 		ServicePort: service.ContainerPort,
 		Intercept: intercept,
 		InterceptPort: service.InterceptPort,
+		ContainerName: containerName,
 	}
 
 	msg, err := writeCommand(cmd)

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func main() {
 		Run: handleDebugEnable,
 	}
 	debugEnableCmd.Flags().Bool("intercept", false, "Use intercept instead of replace")
+	debugEnableCmd.Flags().String("container", "", "Name of the container in the pod to replace (telepresence --container)")
 	debugDisableCmd := &cobra.Command{
 		Use:   "disable <service>",
 		Short: "Disable debug mode for a service",
@@ -168,6 +169,7 @@ func handleDebugList(cmd *cobra.Command, args []string) {
 func handleDebugEnable(cmd *cobra.Command, args []string) {
 	// Disable replace if --intercept flag is set
 	useIntercept,_ := cmd.Flags().GetBool("intercept")
+	containerName, _ := cmd.Flags().GetString("container")
 
 	argServiceName := args[0]
 	service := cfg.Service{}
@@ -182,7 +184,7 @@ func handleDebugEnable(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Printf("Enabling debug mode for service %s\n", argServiceName)
-	debug.Enable(service, config, useIntercept)
+	debug.Enable(service, config, useIntercept, containerName)
 }
 
 func handleDebugDisable(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
adds the `--container` option to the `debug` command to specify which container to debug if your pod has multiple containers. Great when you have sidecars.